### PR TITLE
FIX: Added current directory to the build docker command in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Maven command is executed in the `maven_runner.sh`, that reports back to the `do
 
 ### Build docker image
 
-`docker build -t karate_docker`
+`docker build -t karate_docker .`
 
 ### Run docker image
 


### PR DESCRIPTION
There is a missing `.`, current directory, which is required as an additional argument to specify the location of the Dockerfile.

PS: Found this project while I was looking around for a simple karate dsl + gradle setup and it was easy to follow.